### PR TITLE
drop ruby version down to  => 2.4

### DIFF
--- a/spree_mail_settings.gemspec
+++ b/spree_mail_settings.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version     = SpreeMailSettings.version
   s.summary     = 'Mail setting functionality extracted from Spree Commerce'
   s.description = s.summary
-  s.required_ruby_version = '>= 2.5.7'
+  s.required_ruby_version = '>= 2.4.0'
 
   s.author    = 'John Hawthorn'
   s.email     = 'john.hawthorn@gmail.com'

--- a/spree_mail_settings.gemspec
+++ b/spree_mail_settings.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '>= 3.7.0', '< 5.0'
+  spree_version = '>= 3.5.0', '< 5.0'
   s.add_runtime_dependency 'spree_backend', spree_version
   s.add_runtime_dependency 'spree_core', spree_version
   s.add_runtime_dependency 'spree_auth_devise', spree_version


### PR DESCRIPTION
dropped ruby version to => 2.4 because gem now requires ruby  => 2.5.7